### PR TITLE
Fixes cross compiling on macOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,11 @@
-
-
-#[cfg(target_os = "macos")]
 fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or("".to_string());
+    if target_os == "macos" {
+        build_macos();
+    }
+}
 
+fn build_macos() {
     use std::env;
     use std::path::PathBuf;
     // Tell cargo to look for shared libraries in the specified directory
@@ -35,9 +38,4 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
-}
-
-#[cfg(not(target_os = "macos"))]
-fn main() {
-
 }


### PR DESCRIPTION
build.rs now uses env::var("CARGO_CFG_TARGET_OS") to check which os the build is targetting. Unfortunately, in build.rs target_os is always host_os. So we have to check for the enviornment variable.

This is generally the recommened way to check for the target_os inside build.rs:
 - https://docs.rs/build-target/latest/src/build_target/os.rs.html#121
 - https://kazlauskas.me/entries/writing-proper-buildrs-scripts