### PR TITLE
MacOS: Fix IPv6 routes

### DIFF
--- a/src/platform_impl/macos/macos.rs
+++ b/src/platform_impl/macos/macos.rs
@@ -192,7 +192,7 @@ fn message_to_route(hdr: &rt_msghdr, msg: &[u8]) -> Option<Route> {
                 // Logic again taken from route.c (see link above), function `p_sockaddr()`
                 let segs = v6gw.segments();
                 gateway = Some(IpAddr::V6(Ipv6Addr::new(
-                    segs[0], 0, segs[2], segs[3], segs[4], segs[4], segs[6], segs[7],
+                    segs[0], 0, segs[2], segs[3], segs[4], segs[5], segs[6], segs[7],
                 )))
             }
         }


### PR DESCRIPTION
An route message is a rt_msdhdr followed by a list of `struct
sockaddr`. However, the sockaddr can be variable length (in particular
because sockaddr_in6 is larger than sockaddr/sockaddr_in). This commit
fixes the logic of walking the list of sockaddr's.
Also did some refactoring to reduce the scope of some `unsafe` blocks.

Many of these chagnes are based on @adamierymenko's
https://github.com/johnyburd/net-route/pull/4. However that PR had some
bugs of its own.

The logic I'm using is inspired by
https://opensource.apple.com/source/network_cmds/network_cmds-606.40.2/netstat.tproj/route.c.auto.html