### PR TITLE
Switch winapi crate to windows-sys crate.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,12 @@ runner = 'sudo -E'
 
 [target.x86_64-apple-darwin]
 runner = 'sudo -E'
+
+[build]
+# target = ["x86_64-unknown-linux-musl"]
+# target = ["x86_64-unknown-linux-gnu"]
+# target = ["aarch64-linux-android"]
+# target = ["aarch64-apple-ios"]
+# target = ["x86_64-pc-windows-msvc"]
+# target = ["x86_64-apple-darwin"]
+# target = ["x86_64-unknown-freebsd"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,59 @@
+name: Push or PR
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_n_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: rustfmt
+      if: ${{ !cancelled() }}
+      run: cargo fmt --all -- --check
+    - name: check
+      if: ${{ !cancelled() }}
+      run: cargo check --verbose
+    - name: clippy
+      if: ${{ !cancelled() }}
+      run: cargo clippy --all-targets --all-features -- -D warnings
+    - name: Build
+      if: ${{ !cancelled() }}
+      run: |
+        cargo build --verbose --examples --tests --all-features
+        cargo clean
+        cargo build --verbose --examples --tests --no-default-features
+    - name: Abort on error
+      if: ${{ failure() }}
+      run: echo "Some of jobs failed" && false
+
+  semver:
+    name: Check semver
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check semver
+        if: ${{ !cancelled() }}
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+      - name: Abort on error
+        if: ${{ failure() }}
+        run: echo "Semver check failed" && false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,32 +18,48 @@ targets = [
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",
     "x86_64-pc-windows-msvc",
-    "i686-pc-windows-msvc"
+    "i686-pc-windows-msvc",
 ]
 
-
 [dependencies]
-tokio = { version = "1", features = ["macros", "rt", "fs", "io-util", "sync", "net"] }
-futures = "0.3.24"
 async-stream = "0.3.3"
-
+futures = "0.3.24"
+tokio = { version = "1", features = [
+    "macros",
+    "rt",
+    "fs",
+    "io-util",
+    "sync",
+    "net",
+] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.14"
 netlink-sys = "0.8.5"
 netlink-packet-core = "0.7.0"
-netlink-packet-route = "0.19"
+netlink-packet-route = "0.21"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.9", features = [
-    "netioapi",
-    "winerror",
-    "ws2def",
-    "ifdef"
+windows-sys = { version = "0.59", features = [
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_SystemServices",
+    "Win32_Security_Cryptography",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
+    "Win32_System_Threading",
+    "Win32_System_Com",
+    "Win32_System_Rpc",
+    "Win32_Security",
+    "Win32_Foundation",
+    "Win32_System_Ioctl",
+    "Win32_System_IO",
+    "Win32_System_LibraryLoader",
+    "Win32_Security_WinTrust",
 ] }
 
 [build-dependencies]
-bindgen = "0.69.1"
+bindgen = "0.70"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1", features = [
 rtnetlink = "0.14"
 netlink-sys = "0.8.5"
 netlink-packet-core = "0.7.0"
-netlink-packet-route = "0.21"
+netlink-packet-route = "0.19"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ fn main() {
     // detect docs rs builder so we don't try to link to macos libs while cross compiling
     let docs_builder = std::env::var("DOCS_RS").is_ok();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    
+
     if target_os == "macos" && !docs_builder {
         build_macos();
     }

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -1,4 +1,4 @@
-use net_route::{Route, Handle};
+use net_route::{Handle, Route};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -1,4 +1,3 @@
-
 use net_route::Handle;
 
 #[tokio::main]

--- a/examples/delete.rs
+++ b/examples/delete.rs
@@ -1,14 +1,14 @@
-use net_route::{Route, Handle};
+use net_route::{Handle, Route};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     let handle = Handle::new()?;
     // warning: this may break network connecitivity
     let route = Route::new("192.168.2.0".parse().unwrap(), 26);
-        // windows options
-        //.with_luid(19985273102270464)
-        //.with_metric(5)
-        //.with_ifindex(6);
+    // windows options
+    //.with_luid(19985273102270464)
+    //.with_metric(5)
+    //.with_ifindex(6);
     println!("route delete {:?} {}", route, route.mask());
     handle.delete(&route).await
 }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -6,6 +6,7 @@ async fn main() -> std::io::Result<()> {
     let routes = handle.list().await?;
 
     for route in routes {
+        #[cfg(target_os = "linux")]
         println!(
             "{}/{} -> via {:?} dev {:?} src {:?}/{}",
             route.destination,
@@ -14,6 +15,11 @@ async fn main() -> std::io::Result<()> {
             route.ifindex,
             route.source,
             route.source_prefix,
+        );
+        #[cfg(not(target_os = "linux"))]
+        println!(
+            "{}/{} -> via {:?} dev {:?}",
+            route.destination, route.prefix, route.gateway, route.ifindex,
         );
     }
     Ok(())

--- a/examples/listen.rs
+++ b/examples/listen.rs
@@ -1,4 +1,3 @@
-
 use futures::StreamExt;
 use net_route::Handle;
 

--- a/src/platform_impl/macos/bind.rs
+++ b/src/platform_impl/macos/bind.rs
@@ -2,4 +2,5 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(clippy::useless_transmute)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -1,4 +1,6 @@
 mod bind;
+
+#[allow(clippy::module_inception)]
 pub(crate) mod macos;
 
 pub(crate) use macos::Handle;


### PR DESCRIPTION
Since the `winapi` crate has not been updated for 4 years, it is necessary to switch it to the `windows-sys` crate, which is Microsoft's official crate and is actively maintained.